### PR TITLE
Abort playbook early without extra var

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -4,6 +4,12 @@
   debug:
     msg: "distribution: {{ ansible_distribution }}, major_version: {{ ansible_distribution_major_version }}"
 
+- name: Ensure single tcinterfaces definition
+  assert:
+    that: (shorewall_tcinterfaces is undefined) or (shorewall6_tcinterfaces is undefined)
+    fail_msg: "only one of shorewall_tcinterfaces and shorewall6_tcinterfaces may be defined"
+    quiet: true
+
 - name: Add OS specific variables
   include_vars: "{{ item }}"
   with_first_found:
@@ -27,8 +33,3 @@
   debug:
     msg: "Skipped Shorewall6 configuration because dead man's switch var 'shorewall6_run' is not set to true"
   when: not shorewall6_run|bool
-
-- name: Abort if tcinterfaces vars exist for both Shorewall and Shorewall6
-  debug:
-    msg: "Aborted Shorewall configuration because tcinterfaces is defined in both Shorewall and Shorewall6 vars... you can only define this once"
-  when: shorewall_duplicate_tcinterfaces is defined

--- a/tasks/sw_run.yml
+++ b/tasks/sw_run.yml
@@ -16,13 +16,8 @@
     state: present
     reload: yes
 
-- name: Shorewall duplicate TC Interfaces entries check
-  set_fact:
-    shorewall_duplicate_tcinterfaces: true
-  when: (shorewall_tcinterfaces is defined) and (shorewall6_tcinterfaces is defined)
-
 - include: shorewall.yml
-  when: (shorewall_run|bool) and (not shorewall_duplicate_tcinterfaces is defined)
+  when: (shorewall_run|bool)
 
 - include: shorewall6.yml
-  when: (shorewall6_run|bool) and (not shorewall_duplicate_tcinterfaces is defined)
+  when: (shorewall6_run|bool)


### PR DESCRIPTION
Tested ok. Play is marked as failed when both are defined:

	- hosts: 127.0.0.1
	  roles:
	    - role: sol1-shorewall
	      vars:
	        shorewall_tcinterfaces: true
	        shorewall6_tcinterfaces: true

`ansible-playbook` output:

	TASK [sol1-shorewall : Ensure single tcinterfaces definition] ******************
	fatal: [127.0.0.1]: FAILED! => {"assertion": "(shorewall_tcinterfaces is undefined) or (shorewall6_tcinterfaces is undefined)", "changed": false, "evaluated_to": false, "msg": "only one of shorewall_tcinterfaces and shorewall6_tcinterfaces may be defined"}

Play proceeds (quietly) if only one of the tcinterfaces variables is defined:

	- hosts: 127.0.0.1
	  roles:
	    - role: sol1-shorewall
	      vars:
	        shorewall6_tcinterfaces: true

And `ansible-playbook` output:

	TASK [sol1-shorewall : Ensure single tcinterfaces definition] ******************
	ok: [127.0.0.1]
