### PR TITLE
Added Generate Shorewall init, start, started, stop, stopped task to tasks/shorewall[6].yml w/ required templates

### DIFF
--- a/README.md
+++ b/README.md
@@ -299,8 +299,28 @@ shorewall_tunnels:
   - { type: ipsec, zone: net, gateway: "0.0.0.0/0", gateway_zones: "vpn1,vpn2" }
 ```
 
+### shorewall[6]_[init|start|started|stop|stopped]
 
- 
+Define shell commands at runtimes
+
+/etc/shorewall[6]/init - shell commands that you wish to execute at the beginning of a “shorewall start”, "shorewall reload" or “shorewall restart”. 
+
+/etc/shorewall[6]/start - shell commands that you wish to execute near the completion of a “shorewall start”, "shorewall reload" or “shorewall restart” 
+
+/etc/shorewall[6]/started - shell commands that you wish to execute after the completion of a “shorewall start”, "shorewall reload" or “shorewall restart” 
+
+/etc/shorewall[6]/stop - commands that you wish to execute at the beginning of a “shorewall stop”. 
+
+/etc/shorewall[6]/stopped - shell commands that you wish to execute at the completion of a “shorewall stop”. 
+
+
+#### Example
+
+```yaml
+shorewall_started:
+  - { comment: "conntrack -F is good for your health (Dave)", command: "conntrack -F" }
+```
+
 ## Example Playbook
 
 ```yml

--- a/tasks/shorewall.yml
+++ b/tasks/shorewall.yml
@@ -4,6 +4,8 @@
 - name: Combine all Shorewall configuration variables
   set_fact:
     shorewall_conf: "{{ shorewall_conf_defaults|combine(shorewall_conf, recursive=True) }}"
+  tags:
+    - configuration
 
 - name: Install Shorewall and dependencies
   package:
@@ -19,10 +21,14 @@
   command: shorewall version
   register: shorewall_version_result
   changed_when: False
+  tags:
+    - configuration
 
 - name: Convert Shorewall version var
   set_fact:
     shorewall_version: "{{ '.'.join( shorewall_version_result.get('stdout', '0.0').split('.')[:2] ) }}"
+  tags:
+    - configuration
 
 - name: Generate Shorewall essential configuration files
   template:
@@ -256,11 +262,31 @@
     - configuration
   when: (shorewall_version|float >= 5.0) and (shorewall_masq is defined or shorewall_snat is defined)
 
+- name: Generate Shorewall init, start, started, stop, stopped files
+  template:
+    dest: "/etc/shorewall/{{ item.name }}"
+    src: "shorewall/{{ item.name }}.j2"
+    owner: root
+    group: root
+    mode: 0640
+  notify:
+    - restart shorewall
+  tags:
+    - configuration
+  with_items:
+    - { name: 'init', when: "{{ shorewall_init | default(False) }}" }
+    - { name: 'start', when: "{{ shorewall_start | default(False) }}" }
+    - { name: 'started', when: "{{ shorewall_started | default(False) }}" }
+    - { name: 'stop', when: "{{ shorewall_stop | default(False) }}" }
+    - { name: 'stopped', when: "{{ shorewall_stopped | default(False) }}" }
+  when: item.when
+
 - name: Verify Shorewall configuration
   command: shorewall check
   changed_when: False
   tags:
     - tests
+    - configuration
 
 - name: Generate Shorewall service configuration
   template:

--- a/tasks/shorewall6.yml
+++ b/tasks/shorewall6.yml
@@ -4,6 +4,8 @@
 - name: Combine all Shorewall6 configuration variables
   set_fact:
     shorewall6_conf: "{{ shorewall6_conf_defaults|combine(shorewall6_conf, recursive=True) }}"
+  tags:
+    - configuration
 
 - name: Install Shorewall6 and dependencies
   package:
@@ -20,10 +22,14 @@
     command: shorewall6 version
     register: shorewall6_version_result
     changed_when: False
+    tags:
+      - configuration
 
   - name: Convert Shorewall6 version var
     set_fact:
       shorewall6_version: "{{ '.'.join( shorewall6_version_result.get('stdout', '0.0').split('.')[:2] ) }}"
+    tags:
+      - configuration
 
   - name: Generate Shorewall6 essential configuration files
     template:
@@ -257,11 +263,31 @@
       - configuration
     when: (shorewall6_version|float >= 5.0) and (shorewall6_masq is defined or shorewall6_snat is defined)
 
+  - name: Generate Shorewall6 init, start, started, stop, stopped files
+    template:
+      dest: "/etc/shorewall6/{{ item.name }}"
+      src: "shorewall6/{{ item.name }}.j2"
+      owner: root
+      group: root
+      mode: 0640
+    notify:
+      - restart shorewall
+    tags:
+      - configuration
+    with_items:
+      - { name: 'init', when: "{{ shorewall6_init | default(False) }}" }
+      - { name: 'start', when: "{{ shorewall6_start | default(False) }}" }
+      - { name: 'started', when: "{{ shorewall6_started | default(False) }}" }
+      - { name: 'stop', when: "{{ sshorewall6_stop | default(False) }}" }
+      - { name: 'stopped', when: "{{ shorewall6_stopped | default(False) }}" }
+    when: item.when
+
   - name: Verify Shorewall6 configuration
     command: shorewall6 check
     changed_when: False
     tags:
       - tests
+      - configuration
 
   - name: Generate Shorewall6 service configuration
     template:

--- a/tasks/shorewall6.yml
+++ b/tasks/shorewall6.yml
@@ -271,7 +271,7 @@
       group: root
       mode: 0640
     notify:
-      - restart shorewall
+      - restart shorewall6
     tags:
       - configuration
     with_items:

--- a/templates/shorewall/init.j2
+++ b/templates/shorewall/init.j2
@@ -1,0 +1,5 @@
+# shell commands that you wish to execute at the beginning of a “shorewall start”, "shorewall reload" or “shorewall restart”.
+
+{% for i in shorewall_init %}{% if i.comment is defined %}# {{ i.comment }} {% endif %} 
+{{ i.command }}
+{% endfor %}

--- a/templates/shorewall/start.j2
+++ b/templates/shorewall/start.j2
@@ -1,0 +1,5 @@
+# shell commands that you wish to execute near the completion of a “shorewall start”, "shorewall reload" or “shorewall restart”
+
+{% for i in shorewall_start %}{% if i.comment is defined %}# {{ i.comment }} {% endif %} 
+{{ i.command }}
+{% endfor %}

--- a/templates/shorewall/started.j2
+++ b/templates/shorewall/started.j2
@@ -1,0 +1,5 @@
+# shell commands that you wish to execute after the completion of a “shorewall start”, "shorewall reload" or “shorewall restart”
+
+{% for i in shorewall_started %}{% if i.comment is defined %}# {{ i.comment }} {% endif %} 
+{{ i.command }}
+{% endfor %}

--- a/templates/shorewall/stop.j2
+++ b/templates/shorewall/stop.j2
@@ -1,0 +1,5 @@
+# shell commands that you wish to execute at the beginning of a “shorewall stop”.
+
+{% for i in shorewall_stop %}{% if i.comment is defined %}# {{ i.comment }} {% endif %} 
+{{ i.command }}
+{% endfor %}

--- a/templates/shorewall/stopped.j2
+++ b/templates/shorewall/stopped.j2
@@ -1,0 +1,5 @@
+# shell commands that you wish to execute at the completion of a “shorewall stop”.
+
+{% for i in shorewall_stopped %}{% if i.comment is defined %}# {{ i.comment }} {% endif %} 
+{{ i.command }}
+{% endfor %}

--- a/templates/shorewall6/init.j2
+++ b/templates/shorewall6/init.j2
@@ -1,0 +1,5 @@
+# shell commands that you wish to execute at the beginning of a “shorewall start”, "shorewall reload" or “shorewall restart”.
+
+{% for i in shorewall6_init %}{% if i.comment is defined %}# {{ i.comment }} {% endif %} 
+{{ i.command }}
+{% endfor %}

--- a/templates/shorewall6/start.j2
+++ b/templates/shorewall6/start.j2
@@ -1,0 +1,5 @@
+# shell commands that you wish to execute near the completion of a “shorewall start”, "shorewall reload" or “shorewall restart”
+
+{% for i in shorewall6_start %}{% if i.comment is defined %}# {{ i.comment }} {% endif %} 
+{{ i.command }}
+{% endfor %}

--- a/templates/shorewall6/started.j2
+++ b/templates/shorewall6/started.j2
@@ -1,0 +1,5 @@
+# shell commands that you wish to execute after the completion of a “shorewall start”, "shorewall reload" or “shorewall restart”
+
+{% for i in shorewall6_started %}{% if i.comment is defined %}# {{ i.comment }} {% endif %} 
+{{ i.command }}
+{% endfor %}

--- a/templates/shorewall6/stop.j2
+++ b/templates/shorewall6/stop.j2
@@ -1,0 +1,5 @@
+# shell commands that you wish to execute at the beginning of a “shorewall stop”.
+
+{% for i in shorewall6_stop %}{% if i.comment is defined %}# {{ i.comment }} {% endif %} 
+{{ i.command }}
+{% endfor %}

--- a/templates/shorewall6/stopped.j2
+++ b/templates/shorewall6/stopped.j2
@@ -1,0 +1,5 @@
+# shell commands that you wish to execute at the completion of a “shorewall stop”.
+
+{% for i in shorewall6_stopped %}{% if i.comment is defined %}# {{ i.comment }} {% endif %} 
+{{ i.command }}
+{% endfor %}


### PR DESCRIPTION
Added task to tasks/shorewall[6].yml w/ required templates: Generate Shorewall init, start, started, stop, stopped files, also fixed tag "configuration", which was broken - because of dependencies not being tagged also. ie, shorewall_version, shorewall_conf.startup dict, which was combined from shorewall_conf_defaults at the beginning.... 